### PR TITLE
BUG: Cuando se tiene un solo decimal y se debe colocar el segundo con 0

### DIFF
--- a/src/NumerosEnLetras.php
+++ b/src/NumerosEnLetras.php
@@ -69,6 +69,8 @@ class NumerosEnLetras
         if(count($div_decimales) > 1){
             $base_number = $div_decimales[0];
             $decNumberStr = (string) $div_decimales[1];
+            if(strlen($decNumberStr)==1)
+                $decNumberStr = $decNumberStr.'0' ;
             if(strlen($decNumberStr) == 2){
                 $decNumberStrFill = str_pad($decNumberStr, 9, '0', STR_PAD_LEFT);
                 $decCientos = substr($decNumberStrFill, 6);


### PR DESCRIPTION
En el caso siguiente:
cuando tienes registrado un double con un solo decimal es decir 2.2 el cuando muestra el literal el decimal sale 00/100 en ves de 20/100 y lo arregle con una condicional para agregar un 0 al $decNumberStr